### PR TITLE
Make udev rule only apply to first PL011 UART

### DIFF
--- a/etc.armhf/udev/rules.d/99-com.rules
+++ b/etc.armhf/udev/rules.d/99-com.rules
@@ -19,22 +19,9 @@ SUBSYSTEM=="pwm*", PROGRAM="/bin/sh -c '\
 	chown -R root:gpio /sys/devices/platform/soc/*.pwm/pwm/pwmchip* && chmod -R 770 /sys/devices/platform/soc/*.pwm/pwm/pwmchip*\
 '"
 
-KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
+KERNEL=="ttyAMA[01]", ATTR{iomem_base}=="0xFE201000", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
-		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
-		echo 1; \
-	else \
-		exit 1; \
-	fi\
-'", SYMLINK+="serial%c"
-
-KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
-	ALIASES=/proc/device-tree/aliases; \
-	if [ -e /dev/ttyAMA0 ]; then \
-		exit 1; \
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
 		echo 0;\
 	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
 		echo 1; \


### PR DESCRIPTION
Make sure the rule applies to the first PL011 UART by checking iomem base.

I had a hard time to understand https://github.com/RPi-Distro/raspberrypi-sys-mods/commit/05cfe136f76677a891a0c77dc91d796913607c07#diff-2678c183f503319c8d8c09c818af789a. I think this is a more elegant way of doing the same.